### PR TITLE
Added support for timedelta expiration like redis-py

### DIFF
--- a/redis_dict.py
+++ b/redis_dict.py
@@ -1,4 +1,5 @@
 import json
+from datetime import timedelta
 from typing import Any, Callable, Dict, Iterator, Set, List, Tuple, Union, Optional
 from redis import StrictRedis
 
@@ -123,7 +124,7 @@ class RedisDict:
 
     def __init__(self,
                  namespace: str = 'main',
-                 expire: Union[int, None] = None,
+                 expire: Union[int, timedelta, None] = None,
                  preserve_expiration: Optional[bool] = False,
                  **redis_kwargs: Any) -> None:
         """
@@ -131,13 +132,13 @@ class RedisDict:
 
         Args:
             namespace (str, optional): A prefix for keys stored in Redis.
-            expire (int, optional): Expiration time for keys in seconds.
+            expire (int, timedelta, optional): Expiration time for keys in seconds.
             preserve_expiration (bool, optional): Whether or not to preserve the expiration.
             **redis_kwargs: Additional keyword arguments passed to StrictRedis.
         """
         self.temp_redis: Optional[StrictRedis[Any]] = None
         self.namespace: str = namespace
-        self.expire: Union[int, None] = expire
+        self.expire: Union[int, timedelta, None] = expire
         self.preserve_expiration: Optional[bool] = preserve_expiration
         self.redis: StrictRedis[Any] = StrictRedis(decode_responses=True, **redis_kwargs)
         self.get_redis: StrictRedis[Any] = self.redis
@@ -640,12 +641,12 @@ class RedisDict:
         return self.__delitem__(':'.join(iterable))
 
     @contextmanager
-    def expire_at(self, sec_epoch: int) -> Iterator[None]:
+    def expire_at(self, sec_epoch: int | timedelta) -> Iterator[None]:
         """
         Context manager to set the expiration time for keys in the RedisDict.
 
         Args:
-            sec_epoch (int): The expiration time in Unix timestamp format.
+            sec_epoch (int, timedelta): The expiration time in Unix timestamp format.
 
         Returns:
             ContextManager: A context manager during which the expiration time is the time set.

--- a/redis_dict.py
+++ b/redis_dict.py
@@ -646,7 +646,7 @@ class RedisDict:
         Context manager to set the expiration time for keys in the RedisDict.
 
         Args:
-            sec_epoch (int, timedelta): The expiration time in Unix timestamp format.
+            sec_epoch (int, timedelta): The expiration duration is set using either an integer or a timedelta.
 
         Returns:
             ContextManager: A context manager during which the expiration time is the time set.

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,6 @@
 import time
 import unittest
+from datetime import timedelta
 
 import redis
 
@@ -808,19 +809,31 @@ class TestRedisDict(unittest.TestCase):
     def test_expire_context(self):
         """Test adding keys with an expire value by using the contextmanager."""
         with self.r.expire_at(3600):
-            self.r['foobar'] = 'barbar'
+            self.r['foobar1'] = 'barbar1'
+        print(type(timedelta(hours=0.25, minutes=15, seconds=900)))
+        with self.r.expire_at(timedelta(hours=0.25, minutes=15, seconds=900)):
+            self.r['foobar2'] = 'barbar2'
 
-        actual_ttl = self.redisdb.ttl('{}:foobar'.format(TEST_NAMESPACE_PREFIX))
+        actual_ttl = self.redisdb.ttl('{}:foobar1'.format(TEST_NAMESPACE_PREFIX))
         self.assertAlmostEqual(3600, actual_ttl, delta=2)
+        actual_ttl = self.redisdb.ttl('{}:foobar2'.format(TEST_NAMESPACE_PREFIX))
+        self.assertAlmostEqual(2700, actual_ttl, delta=2)
 
     def test_expire_keyword(self):
         """Test ading keys with an expire value by using the expire config keyword."""
         r = self.create_redis_dict(expire=3600)
 
-        r['foobar'] = 'barbar'
+        r['foobar1'] = 'barbar1'
         actual_ttl = self.redisdb.ttl('{}:foobar'.format(TEST_NAMESPACE_PREFIX))
         self.assertAlmostEqual(3600, actual_ttl, delta=2)
 
+        r.clear()
+
+        r = self.create_redis_dict(expire=timedelta(hours=0.25, minutes=15, seconds=900))
+
+        r['foobar2'] = 'barbar2'
+        actual_ttl = self.redisdb.ttl('{}:foobar'.format(TEST_NAMESPACE_PREFIX))
+        self.assertAlmostEqual(2700, actual_ttl, delta=2)
     def test_iter(self):
         """Tests the __iter__ function."""
         key_values = {


### PR DESCRIPTION
redis-py already supports EX in int as seconds since epoch or as timedelta, this PR exposes the timedelta possibility for expiration from redis-py to redis-dict.

Additionally i added some tests to make sure it is all covered but those could potentially be left out because their functionality might be tested by redis-py already.