### PR TITLE
add possibility to pass connection

### DIFF
--- a/redis_dict.py
+++ b/redis_dict.py
@@ -214,7 +214,7 @@ class RedisDict:
                  namespace: str = 'main',
                  expire: Union[int, timedelta, None] = None,
                  preserve_expiration: Optional[bool] = False,
-                 redis: Optional[StrictRedis[Any]] = None,
+                 redis: "Optional[StrictRedis[Any]]" = None,
                  **redis_kwargs: Any) -> None:
         """
         Initialize a RedisDict instance.

--- a/redis_dict.py
+++ b/redis_dict.py
@@ -273,7 +273,7 @@ class RedisDict:
         if val_type == "str":
             return len(val) < self._max_string_size
         return True
-    
+
     def _format_value(self, key: str,  value: Any) -> str:
         store_type, key = type(value).__name__, str(key)
         if not self._valid_input(value, store_type) or not self._valid_input(key, "str"):

--- a/redis_dict.py
+++ b/redis_dict.py
@@ -214,7 +214,7 @@ class RedisDict:
                  namespace: str = 'main',
                  expire: Union[int, timedelta, None] = None,
                  preserve_expiration: Optional[bool] = False,
-                 redis: Optional[StrictRedis] = None,
+                 redis: Optional[StrictRedis[Any]] = None,
                  **redis_kwargs: Any) -> None:
         """
         Initialize a RedisDict instance.

--- a/redis_dict.py
+++ b/redis_dict.py
@@ -272,6 +272,14 @@ class RedisDict:
         if val_type == "str":
             return len(val) < self._max_string_size
         return True
+    
+    def _format_value(self, key: str,  value: Any) -> str:
+        store_type, key = type(value).__name__, str(key)
+        if not self._valid_input(value, store_type) or not self._valid_input(key, "str"):
+            raise ValueError("Invalid input value or key size exceeded the maximum limit.")
+        encoded_value = self.encoding_registry.get(store_type, lambda x: x)(value)  # type: ignore
+
+        return f'{store_type}:{encoded_value}'
 
     def _store(self, key: str, value: Any) -> None:
         """

--- a/redis_dict.py
+++ b/redis_dict.py
@@ -158,8 +158,11 @@ def _encode_set(val: Set[Any]) -> str:
     """
     return json.dumps(list(val))
 
+
 _RedisValue = TypeVar("_RedisValue")
 _DefaultValue = TypeVar("_DefaultValue")
+
+
 # pylint: disable=R0902, R0904
 class RedisDict(Generic[_RedisValue]):
     """
@@ -748,7 +751,7 @@ class RedisDict(Generic[_RedisValue]):
         value = self.get_redis.execute_command("GETDEL", formatted_key)
         if value is None:
             if default is not SENTINEL:
-                return default
+                return default  # type: ignore
             raise KeyError(formatted_key)
 
         return self._transform(value)

--- a/redis_dict.py
+++ b/redis_dict.py
@@ -214,6 +214,7 @@ class RedisDict:
                  namespace: str = 'main',
                  expire: Union[int, timedelta, None] = None,
                  preserve_expiration: Optional[bool] = False,
+                 redis: Optional[StrictRedis] = None,
                  **redis_kwargs: Any) -> None:
         """
         Initialize a RedisDict instance.
@@ -222,13 +223,16 @@ class RedisDict:
             namespace (str, optional): A prefix for keys stored in Redis.
             expire (int, timedelta, optional): Expiration time for keys in seconds.
             preserve_expiration (bool, optional): Preserve the expiration count when the key is updated.
-            **redis_kwargs: Additional keyword arguments passed to StrictRedis.
+            redis (StrictRedis, optional): A pre-defined redis connection object
+            **redis_kwargs: Additional keyword arguments passed to StrictRedis if connection is not given.
         """
 
         self.namespace: str = namespace
         self.expire: Union[int, timedelta, None] = expire
         self.preserve_expiration: Optional[bool] = preserve_expiration
-        self.redis: StrictRedis[Any] = StrictRedis(decode_responses=True, **redis_kwargs)
+        if redis:
+            redis.connection_pool.connection_kwargs["decode_responses"] = True
+        self.redis: StrictRedis[Any] = redis or StrictRedis(decode_responses=True, **redis_kwargs)
         self.get_redis: StrictRedis[Any] = self.redis
 
         self.custom_encode_method = "encode"

--- a/redis_dict.py
+++ b/redis_dict.py
@@ -232,6 +232,7 @@ class RedisDict:
         self.preserve_expiration: Optional[bool] = preserve_expiration
         if redis:
             redis.connection_pool.connection_kwargs["decode_responses"] = True
+
         self.redis: StrictRedis[Any] = redis or StrictRedis(decode_responses=True, **redis_kwargs)
         self.get_redis: StrictRedis[Any] = self.redis
 

--- a/redis_dict.py
+++ b/redis_dict.py
@@ -273,7 +273,7 @@ class RedisDict:
             return len(val) < self._max_string_size
         return True
 
-    def _store(self, key: str, value: _RedisValue) -> None:
+    def _store(self, key: str, value: Any) -> None:
         """
         Store a value in Redis with the given key.
 

--- a/tests.py
+++ b/tests.py
@@ -1655,6 +1655,10 @@ class TestRedisDictWithHypothesis(unittest.TestCase):
         self.r[key] = value
         self.assertEqual(self.r[key], value)
 
+    def test_init_with_from_url(self):
+        redisd = RedisDict(redis=redis.StrictRedis.from_url("redis://127.0.0.1/0"))
+        redisd["test_key"] = "test_value"
+        self.assertEqual(redisd["test_key"], "test_value")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR does two things:

1. Add the possibility to pass a prepared connection object to RedisDict. This is meant to allow usage of `Redis.from_url` and other methods that could be used to create a redis object
2. Make RedisDict generic. This allows users to apply a contracts on their api with help of linters like mypy. One could do `var: dict[str, ...] = RedisDict(...)` as well, but then methods like the `extend_type` methods would be "lost".

I'm open to feedback. Let me hear what you think :)