### PR TITLE
Add configurable separator and nested dict support (#52)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ exclude_lines = [
 show_missing = true
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.9"
 strict = true
 mypy_path = "src"
 files = ["src"]

--- a/src/redis_dict/core.py
+++ b/src/redis_dict/core.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Iterator, List, Tuple, Union, Optional, Type
 
 from datetime import timedelta
 from contextlib import contextmanager
-from collections.abc import Mapping
+from collections.abc import Mapping, MutableMapping
 
 from redis import StrictRedis
 
@@ -15,7 +15,7 @@ from .type_management import decoding_registry as dec_reg
 _DEFAULT_SEPARATOR = '➡️    '
 
 
-class _NestedDictProxy(Mapping):
+class _NestedDictProxy(MutableMapping):
     """Proxy for a nested dict stored as chain keys in Redis.
 
     Returned by :meth:`RedisDict.__getitem__` when the retrieved value is a

--- a/src/redis_dict/core.py
+++ b/src/redis_dict/core.py
@@ -987,6 +987,11 @@ class RedisDict:
         flat = self._structured_to_flattened_dict(value, self.separator)
         # Remove any pre-existing scalar stored at the parent key.
         self.redis.delete(formatted_key)
+        if not flat:
+            # Empty dict (or a dict whose only leaves are empty dicts) has no
+            # chain keys to store, so fall back to storing it as a scalar value.
+            self._store(key, value)
+            return
         for sub_key, v in flat.items():
             self._store(f"{key}{self.separator}{sub_key}", v)
 

--- a/src/redis_dict/core.py
+++ b/src/redis_dict/core.py
@@ -1,5 +1,5 @@
 """Redis Dict module."""
-from typing import Any, Dict, Iterator, List, Tuple, Union, Optional, Type
+from typing import Any, Dict, Iterator, List, Tuple, Union, Optional, Type, cast
 
 from datetime import timedelta
 from contextlib import contextmanager
@@ -15,7 +15,7 @@ from .type_management import decoding_registry as dec_reg
 _DEFAULT_SEPARATOR = '➡️    '
 
 
-class _NestedDictProxy(MutableMapping):
+class _NestedDictProxy(MutableMapping[str, Any]):
     """Proxy for a nested dict stored as chain keys in Redis.
 
     Returned by :meth:`RedisDict.__getitem__` when the retrieved value is a
@@ -238,7 +238,7 @@ class RedisDict:
         result = self.get_redis.get(self._format_key(key))
         if result is None:
             return False, None
-        return True, self._transform(result)
+        return True, self._transform(cast(str, result))
 
     def _transform(self, result: str) -> Any:
         """
@@ -411,7 +411,7 @@ class RedisDict:
             found, value = self._load_nested_dict(item)
             if not found:
                 raise KeyError(item)
-            return _NestedDictProxy(self, item, value)
+            return _NestedDictProxy(self, item, cast(Dict[str, Any], value))
         return value
 
     def __setitem__(self, key: str, value: Any) -> None:
@@ -683,7 +683,7 @@ class RedisDict:
             Iterator[str]: A list of keys in the RedisDict.
         """
         to_rm = len(self.namespace) + 1
-        seen: set = set()
+        seen: set[str] = set()
         result = []
         for redis_key in self._scan_keys():
             k = str(redis_key[to_rm:])
@@ -704,7 +704,7 @@ class RedisDict:
         """
         to_rm = len(self.namespace) + 1
         search_query = self._create_iter_query(search_term)
-        _, data = self.get_redis.scan(match=search_query, count=1)
+        _, data = cast(Tuple[int, List[str]], self.get_redis.scan(match=search_query, count=1))
         for item in data:
             return str(item[to_rm:])
 
@@ -860,7 +860,7 @@ class RedisDict:
         if result is None:
             return default_value
 
-        return self._transform(result)
+        return self._transform(cast(str, result))
 
     def copy(self) -> Dict[str, Any]:
         """Create a shallow copy of the RedisDict and return it as a standard Python dictionary.
@@ -1099,7 +1099,7 @@ class RedisDict:
         found_keys = list(self._scan_keys(key))
         if len(found_keys) == 0:
             return []
-        return [self._transform(i) for i in self.redis.mget(found_keys) if i is not None]
+        return [self._transform(cast(str, i)) for i in cast(List[Any], self.redis.mget(found_keys)) if i is not None]
 
     def multi_chain_get(self, keys: List[str]) -> List[Any]:
         """
@@ -1128,7 +1128,7 @@ class RedisDict:
             return {}
         to_rm = keys[0].rfind(':') + 1
         return dict(
-            zip([i[to_rm:] for i in keys], (self._transform(i) for i in self.redis.mget(keys) if i is not None))
+            zip([i[to_rm:] for i in keys], (self._transform(cast(str, i)) for i in cast(List[Any], self.redis.mget(keys)) if i is not None))
         )
 
     def multi_del(self, key: str) -> int:
@@ -1153,7 +1153,7 @@ class RedisDict:
         Returns:
             dict: The information and statistics from the Redis server in a dictionary.
         """
-        return dict(self.redis.info())
+        return dict(cast(Dict[str, Any], self.redis.info()))
 
     def get_ttl(self, key: str) -> Optional[int]:
         """Get the Time To Live from Redis.

--- a/src/redis_dict/core.py
+++ b/src/redis_dict/core.py
@@ -12,7 +12,8 @@ from .type_management import _create_default_encode, _create_default_decode, _de
 from .type_management import encoding_registry as enc_reg
 from .type_management import decoding_registry as dec_reg
 
-_DEFAULT_SEPARATOR = '➡️    '
+# TODO (major release): reconsider default separator value
+_DEFAULT_CHAIN_SEPARATOR = ':'
 
 
 class _NestedDictProxy(MutableMapping[str, Any]):
@@ -34,16 +35,16 @@ class _NestedDictProxy(MutableMapping[str, Any]):
     def __getitem__(self, key: str) -> Any:
         value = self._data[key]
         if isinstance(value, dict):
-            return _NestedDictProxy(self._rd, f"{self._base_key}{self._rd.separator}{key}", value)
+            return _NestedDictProxy(self._rd, f"{self._base_key}{self._rd.chain_separator}{key}", value)
         return value
 
     def __setitem__(self, key: str, value: Any) -> None:
-        full_key = f"{self._base_key}{self._rd.separator}{key}"
+        full_key = f"{self._base_key}{self._rd.chain_separator}{key}"
         self._rd[full_key] = value
         self._data[key] = value
 
     def __delitem__(self, key: str) -> None:
-        full_key = f"{self._base_key}{self._rd.separator}{key}"
+        full_key = f"{self._base_key}{self._rd.chain_separator}{key}"
         del self._rd[full_key]
         del self._data[key]
 
@@ -98,7 +99,7 @@ class RedisDict:
              preserve_expiration: Optional[bool] = False,
              redis: "Optional[StrictRedis[Any]]" = None,
              raise_key_error_delete: bool = False,
-             separator: str = _DEFAULT_SEPARATOR,
+             chain_separator: str = _DEFAULT_CHAIN_SEPARATOR,
              **redis_kwargs: Any) -> None:  # noqa: D202:R0913 pydocstyle clashes with Sphinx
         """
         Initialize a RedisDict instance.
@@ -111,8 +112,7 @@ class RedisDict:
             preserve_expiration (Optional[bool], optional): Preserve expiration on key updates.
             redis (Optional[StrictRedis[Any]], optional): A Redis connection instance.
             raise_key_error_delete (bool): Enable strict Python dict behavior raise if key not found when deleting.
-            separator (str): Delimiter used to join keys in chain and nested-dict operations. Defaults to '➡️    '
-                , a string that cannot appear in ordinary user keys.
+            chain_separator (str): Delimiter used to join keys in chain and nested-dict operations. Defaults to ':'.
             **redis_kwargs (Any): Additional kwargs for Redis connection if not provided.
         """
 
@@ -120,7 +120,7 @@ class RedisDict:
         self.expire: Union[int, timedelta, None] = expire
         self.preserve_expiration: Optional[bool] = preserve_expiration
         self.raise_key_error_delete: bool = raise_key_error_delete
-        self.separator: str = separator
+        self.chain_separator: str = chain_separator
         if redis:
             redis.connection_pool.connection_kwargs["decode_responses"] = True
 
@@ -427,7 +427,7 @@ class RedisDict:
         if isinstance(value, dict):
             self._store_nested_dict(key, value)
         else:
-            old_nested_keys = list(self._scan_keys(key + self.separator))
+            old_nested_keys = list(self._scan_keys(key + self.chain_separator))
             if old_nested_keys:
                 self.redis.delete(*old_nested_keys)
             self._store(key, value)
@@ -453,7 +453,7 @@ class RedisDict:
         """
         formatted_key = self._format_key(key)
         result = self.redis.delete(formatted_key)
-        nested_deleted = self.multi_del(key + self.separator)
+        nested_deleted = self.multi_del(key + self.chain_separator)
         if not result:
             result = nested_deleted
         if self.raise_key_error_delete and not result:
@@ -689,7 +689,7 @@ class RedisDict:
         result = []
         for redis_key in self._scan_keys():
             k = str(redis_key[to_rm:])
-            logical = k.split(self.separator, 1)[0] if self.separator in k else k
+            logical = k.split(self.chain_separator, 1)[0] if self.chain_separator in k else k
             if logical not in seen:
                 seen.add(logical)
                 result.append(logical)
@@ -983,10 +983,10 @@ class RedisDict:
             value (Dict[str, Any]): The dict whose items will be stored as chain keys.
         """
         formatted_key = self._format_key(key)
-        old_keys = list(self._scan_keys(key + self.separator))
+        old_keys = list(self._scan_keys(key + self.chain_separator))
         if old_keys:
             self.redis.delete(*old_keys)
-        flat = self._structured_to_flattened_dict(value, self.separator)
+        flat = self._structured_to_flattened_dict(value, self.chain_separator)
         # Remove any pre-existing scalar stored at the parent key.
         self.redis.delete(formatted_key)
         if not flat:
@@ -995,7 +995,7 @@ class RedisDict:
             self._store(key, value)
             return
         for sub_key, v in flat.items():
-            self._store(f"{key}{self.separator}{sub_key}", v)
+            self._store(f"{key}{self.chain_separator}{sub_key}", v)
 
     def _load_nested_dict(self, key: str) -> Tuple[bool, Optional[Dict[str, Any]]]:
         """Load a dict assembled from chain keys stored under the given key prefix.
@@ -1010,7 +1010,7 @@ class RedisDict:
                 found is True when at least one chain key exists; result_dict is None
                 when no chain keys were found.
         """
-        search_prefix = key + self.separator
+        search_prefix = key + self.chain_separator
         ns_len = len(self.namespace) + 1  # namespace + ':'
         prefix_len = ns_len + len(search_prefix)
         flat: Dict[str, Any] = {}
@@ -1021,7 +1021,7 @@ class RedisDict:
                 if found:
                     flat[sub_key] = val
         if flat:
-            return True, self._flattened_to_structured_dict(flat, self.separator)
+            return True, self._flattened_to_structured_dict(flat, self.chain_separator)
         return False, None
 
     def chain_set(self, iterable: List[str], v: Any) -> None:
@@ -1032,7 +1032,7 @@ class RedisDict:
             iterable (List[str]): A list of keys representing the chain.
             v (Any): The value to be set.
         """
-        self[self.separator.join(iterable)] = v
+        self[self.chain_separator.join(iterable)] = v
 
     def chain_get(self, iterable: List[str]) -> Any:
         """
@@ -1044,7 +1044,7 @@ class RedisDict:
         Returns:
             Any: The value associated with the chain of keys.
         """
-        return self[self.separator.join(iterable)]
+        return self[self.chain_separator.join(iterable)]
 
     def chain_del(self, iterable: List[str]) -> None:
         """
@@ -1053,7 +1053,7 @@ class RedisDict:
         Args:
             iterable (List[str]): A list of keys representing the chain.
         """
-        del self[self.separator.join(iterable)]
+        del self[self.chain_separator.join(iterable)]
 
     #  def expire_at(self, sec_epoch: int | timedelta) -> Iterator[None]:
     #  compatibility with Python 3.9 typing
@@ -1113,7 +1113,7 @@ class RedisDict:
         Returns:
             List[Any]: A list of values associated with the chain of keys.
         """
-        return self.multi_get(self.separator.join(keys))
+        return self.multi_get(self.chain_separator.join(keys))
 
     def multi_dict(self, key: str) -> Dict[str, Any]:
         """

--- a/src/redis_dict/core.py
+++ b/src/redis_dict/core.py
@@ -12,6 +12,7 @@ from .type_management import _create_default_encode, _create_default_decode, _de
 from .type_management import encoding_registry as enc_reg
 from .type_management import decoding_registry as dec_reg
 
+_DEFAULT_SEPARATOR = '➡️    '
 
 # pylint: disable=R0902, R0904
 class RedisDict:
@@ -47,6 +48,7 @@ class RedisDict:
              preserve_expiration: Optional[bool] = False,
              redis: "Optional[StrictRedis[Any]]" = None,
              raise_key_error_delete: bool = False,
+             separator: str = _DEFAULT_SEPARATOR,
              **redis_kwargs: Any) -> None:  # noqa: D202:R0913 pydocstyle clashes with Sphinx
         """
         Initialize a RedisDict instance.
@@ -59,6 +61,8 @@ class RedisDict:
             preserve_expiration (Optional[bool], optional): Preserve expiration on key updates.
             redis (Optional[StrictRedis[Any]], optional): A Redis connection instance.
             raise_key_error_delete (bool): Enable strict Python dict behavior raise if key not found when deleting.
+            separator (str): Delimiter used to join keys in chain and nested-dict operations. Defaults to '➡️    '
+                , a string that cannot appear in ordinary user keys.
             **redis_kwargs (Any): Additional kwargs for Redis connection if not provided.
         """
 
@@ -66,6 +70,7 @@ class RedisDict:
         self.expire: Union[int, timedelta, None] = expire
         self.preserve_expiration: Optional[bool] = preserve_expiration
         self.raise_key_error_delete: bool = raise_key_error_delete
+        self.separator: str = separator
         if redis:
             redis.connection_pool.connection_kwargs["decode_responses"] = True
 
@@ -352,9 +357,12 @@ class RedisDict:
             KeyError: If the key is not found.
         """
         found, value = self._load(item)
-        if not found:
-            raise KeyError(item)
-        return value
+        if found:
+            return value
+        found, value = self._load_nested_dict(item)
+        if found:
+            return value
+        raise KeyError(item)
 
     def __setitem__(self, key: str, value: Any) -> None:
         """
@@ -364,7 +372,13 @@ class RedisDict:
             key (str): The key to store the value.
             value (Any): The value to be stored.
         """
-        self._store(key, value)
+        if isinstance(value, dict):
+            self._store_nested_dict(key, value)
+        else:
+            old_nested_keys = list(self._scan_keys(key + self.separator))
+            if old_nested_keys:
+                self.redis.delete(*old_nested_keys)
+            self._store(key, value)
 
     def __delitem__(self, key: str) -> None:
         """
@@ -387,6 +401,9 @@ class RedisDict:
         """
         formatted_key = self._format_key(key)
         result = self.redis.delete(formatted_key)
+        nested_deleted = self.multi_del(key + self.separator)
+        if not result:
+            result = nested_deleted
         if self.raise_key_error_delete and not result:
             raise KeyError(key)
 
@@ -400,7 +417,9 @@ class RedisDict:
         Returns:
             bool: True if the key exists, False otherwise.
         """
-        return self._load(key)[0]
+        if self._load(key)[0]:
+            return True
+        return self._load_nested_dict(key)[0]
 
     def __len__(self) -> int:
         """
@@ -409,7 +428,7 @@ class RedisDict:
         Returns:
             int: The number of items in the RedisDict.
         """
-        return sum(1 for _ in self._scan_keys(full_scan=True))
+        return sum(1 for _ in self.keys())
 
     def __iter__(self) -> Iterator[str]:
         """
@@ -600,9 +619,12 @@ class RedisDict:
             Any: The value associated with the key or the default value.
         """
         found, item = self._load(key)
-        if not found:
-            return default
-        return item
+        if found:
+            return item
+        found, item = self._load_nested_dict(key)
+        if found:
+            return item
+        return default
 
     def keys(self) -> Iterator[str]:
         """Return an Iterator of keys in the RedisDict, analogous to a dictionary's keys method.
@@ -611,7 +633,15 @@ class RedisDict:
             Iterator[str]: A list of keys in the RedisDict.
         """
         to_rm = len(self.namespace) + 1
-        return (str(item[to_rm:]) for item in self._scan_keys())
+        seen: set = set()
+        result = []
+        for redis_key in self._scan_keys():
+            k = str(redis_key[to_rm:])
+            logical = k.split(self.separator, 1)[0] if self.separator in k else k
+            if logical not in seen:
+                seen.add(logical)
+                result.append(logical)
+        return iter(result)
 
     def key(self, search_term: str = '') -> Optional[str]:
         """Return the first value for search_term if it exists, otherwise return None.
@@ -636,10 +666,9 @@ class RedisDict:
         Yields:
             Iterator[Tuple[str, Any]]: A list of key-value pairs in the RedisDict.
         """
-        to_rm = len(self.namespace) + 1
-        for item in self._scan_keys():
+        for key in self.keys():
             try:
-                yield str(item[to_rm:]), self[item[to_rm:]]
+                yield key, self[key]
             except KeyError:
                 pass
 
@@ -651,10 +680,9 @@ class RedisDict:
         Yields:
             List[Any]: A list of values in the RedisDict.
         """
-        to_rm = len(self.namespace) + 1
-        for item in self._scan_keys():
+        for key in self.keys():
             try:
-                yield self[item[to_rm:]]
+                yield self[key]
             except KeyError:
                 pass
 
@@ -708,13 +736,14 @@ class RedisDict:
         Raises:
             KeyError: If the key is not found and no default value is provided.
         """
-        formatted_key = self._format_key(key)
-        value = self._pop(formatted_key)
-        if value is None:
+        try:
+            value = self[key]
+            del self[key]
+            return value
+        except KeyError:
             if default is not SENTINEL:
                 return default
-            raise KeyError(formatted_key)
-        return self._transform(value)
+            raise
 
     def popitem(self) -> Tuple[str, Any]:
         """Remove and return a random (key, value) pair from the RedisDict as a tuple.
@@ -730,7 +759,7 @@ class RedisDict:
             KeyError: If RedisDict is empty.
         """
         while True:
-            key = self.key()
+            key = next(iter(self.keys()), None)
             if key is None:
                 raise KeyError("popitem(): dictionary is empty")
             try:
@@ -840,6 +869,104 @@ class RedisDict:
         """
         return self.to_dict().__sizeof__()
 
+    @staticmethod
+    def _structured_to_flattened_dict(nested: Dict[str, Any], separator: str, prefix: str = '') -> Dict[str, Any]:
+        """Recursively flatten a nested dict to a flat dict with separator-joined keys.
+
+        Args:
+            nested (Dict[str, Any]): The nested dict to flatten.
+            separator (str): The separator to join key segments with.
+            prefix (str): Accumulated key prefix for the current recursion level.
+
+        Returns:
+            Dict[str, Any]: A flat dict whose keys are separator-joined paths to leaf values.
+        """
+        flat: Dict[str, Any] = {}
+        for k, v in nested.items():
+            full_key = f"{prefix}{k}"
+            if isinstance(v, dict):
+                flat.update(RedisDict._structured_to_flattened_dict(v, separator, f"{full_key}{separator}"))
+            else:
+                flat[full_key] = v
+        return flat
+
+    @staticmethod
+    def _flattened_to_structured_dict(
+        flat: Dict[str, Any],
+        separator: str,
+        _base: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Recursively reconstruct a nested dict from a flat dict with separator-joined keys.
+
+        Args:
+            flat (Dict[str, Any]): The flat dict to reconstruct.
+            separator (str): The separator used to split key segments.
+            _base (Optional[Dict[str, Any]]): Existing dict to merge results into (used in recursion).
+
+        Returns:
+            Dict[str, Any]: The reconstructed nested dict.
+        """
+        nested: Dict[str, Any] = _base.copy() if _base else {}
+        for k, v in flat.items():
+            if separator in k:
+                first, rest = k.split(separator, 1)
+                if first not in nested:
+                    nested[first] = {}
+                nested[first].update(
+                    RedisDict._flattened_to_structured_dict({rest: v}, separator, nested[first])
+                )
+            else:
+                nested[k] = v
+        return nested
+
+    def _store_nested_dict(self, key: str, value: Dict[str, Any]) -> None:
+        """Store a dict value as individual chain keys in Redis.
+
+        Removes any pre-existing parent key and sub-keys before storing the
+        new leaf values.  Supports arbitrary-depth nesting via
+        ``_structured_to_flattened_dict``.
+
+        Args:
+            key (str): The base key under which to store the nested dict.
+            value (Dict[str, Any]): The dict whose items will be stored as chain keys.
+        """
+        formatted_key = self._format_key(key)
+        old_keys = list(self._scan_keys(key + self.separator))
+        if old_keys:
+            self.redis.delete(*old_keys)
+        flat = self._structured_to_flattened_dict(value, self.separator)
+        # Remove any pre-existing scalar stored at the parent key.
+        self.redis.delete(formatted_key)
+        for sub_key, v in flat.items():
+            self._store(f"{key}{self.separator}{sub_key}", v)
+
+    def _load_nested_dict(self, key: str) -> Tuple[bool, Optional[Dict[str, Any]]]:
+        """Load a dict assembled from chain keys stored under the given key prefix.
+
+        Supports arbitrary-depth nesting via ``_flattened_to_structured_dict``.
+
+        Args:
+            key (str): The base key whose chain sub-keys will be assembled into a dict.
+
+        Returns:
+            Tuple[bool, Optional[Dict[str, Any]]]: A tuple of (found, result_dict).
+                found is True when at least one chain key exists; result_dict is None
+                when no chain keys were found.
+        """
+        search_prefix = key + self.separator
+        ns_len = len(self.namespace) + 1  # namespace + ':'
+        prefix_len = ns_len + len(search_prefix)
+        flat: Dict[str, Any] = {}
+        for redis_key in self._scan_keys(search_prefix):
+            sub_key = redis_key[prefix_len:]
+            if sub_key:
+                found, val = self._load(redis_key[ns_len:])
+                if found:
+                    flat[sub_key] = val
+        if flat:
+            return True, self._flattened_to_structured_dict(flat, self.separator)
+        return False, None
+
     def chain_set(self, iterable: List[str], v: Any) -> None:
         """
         Set a value in the RedisDict using a chain of keys.
@@ -848,7 +975,7 @@ class RedisDict:
             iterable (List[str]): A list of keys representing the chain.
             v (Any): The value to be set.
         """
-        self[':'.join(iterable)] = v
+        self[self.separator.join(iterable)] = v
 
     def chain_get(self, iterable: List[str]) -> Any:
         """
@@ -860,7 +987,7 @@ class RedisDict:
         Returns:
             Any: The value associated with the chain of keys.
         """
-        return self[':'.join(iterable)]
+        return self[self.separator.join(iterable)]
 
     def chain_del(self, iterable: List[str]) -> None:
         """
@@ -869,7 +996,7 @@ class RedisDict:
         Args:
             iterable (List[str]): A list of keys representing the chain.
         """
-        del self[':'.join(iterable)]
+        del self[self.separator.join(iterable)]
 
     #  def expire_at(self, sec_epoch: int | timedelta) -> Iterator[None]:
     #  compatibility with Python 3.9 typing
@@ -929,7 +1056,7 @@ class RedisDict:
         Returns:
             List[Any]: A list of values associated with the chain of keys.
         """
-        return self.multi_get(':'.join(keys))
+        return self.multi_get(self.separator.join(keys))
 
     def multi_dict(self, key: str) -> Dict[str, Any]:
         """

--- a/src/redis_dict/core.py
+++ b/src/redis_dict/core.py
@@ -14,6 +14,56 @@ from .type_management import decoding_registry as dec_reg
 
 _DEFAULT_SEPARATOR = '➡️    '
 
+
+class _NestedDictProxy(Mapping):
+    """Proxy for a nested dict stored as chain keys in Redis.
+
+    Returned by :meth:`RedisDict.__getitem__` when the retrieved value is a
+    nested dict assembled from chain keys.  Writes via ``__setitem__`` are
+    forwarded to Redis so that expressions like ``rd["key"]["sub"] = value``
+    persist correctly without a separate :meth:`RedisDict.chain_set` call.
+    """
+
+    __slots__ = ('_rd', '_base_key', '_data')
+
+    def __init__(self, rd: 'RedisDict', base_key: str, data: Dict[str, Any]) -> None:
+        self._rd = rd
+        self._base_key = base_key
+        self._data = data
+
+    def __getitem__(self, key: str) -> Any:
+        value = self._data[key]
+        if isinstance(value, dict):
+            return _NestedDictProxy(self._rd, f"{self._base_key}{self._rd.separator}{key}", value)
+        return value
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        full_key = f"{self._base_key}{self._rd.separator}{key}"
+        self._rd[full_key] = value
+        self._data[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        full_key = f"{self._base_key}{self._rd.separator}{key}"
+        del self._rd[full_key]
+        del self._data[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, _NestedDictProxy):
+            return self._data == other._data
+        if isinstance(other, dict):
+            return self._data == other
+        return NotImplemented
+
+    def __repr__(self) -> str:
+        return repr(self._data)
+
+
 # pylint: disable=R0902, R0904
 class RedisDict:
     """Python dictionary with Redis as backend.
@@ -357,12 +407,12 @@ class RedisDict:
             KeyError: If the key is not found.
         """
         found, value = self._load(item)
-        if found:
-            return value
-        found, value = self._load_nested_dict(item)
-        if found:
-            return value
-        raise KeyError(item)
+        if not found:
+            found, value = self._load_nested_dict(item)
+            if not found:
+                raise KeyError(item)
+            return _NestedDictProxy(self, item, value)
+        return value
 
     def __setitem__(self, key: str, value: Any) -> None:
         """
@@ -924,7 +974,7 @@ class RedisDict:
 
         Removes any pre-existing parent key and sub-keys before storing the
         new leaf values.  Supports arbitrary-depth nesting via
-        ``_structured_to_flattened_dict``.
+        `_structured_to_flattened_dict`.
 
         Args:
             key (str): The base key under which to store the nested dict.
@@ -943,7 +993,7 @@ class RedisDict:
     def _load_nested_dict(self, key: str) -> Tuple[bool, Optional[Dict[str, Any]]]:
         """Load a dict assembled from chain keys stored under the given key prefix.
 
-        Supports arbitrary-depth nesting via ``_flattened_to_structured_dict``.
+        Supports arbitrary-depth nesting via `_flattened_to_structured_dict`.
 
         Args:
             key (str): The base key whose chain sub-keys will be assembled into a dict.

--- a/src/redis_dict/core.py
+++ b/src/redis_dict/core.py
@@ -422,6 +422,8 @@ class RedisDict:
             key (str): The key to store the value.
             value (Any): The value to be stored.
         """
+        if not self._valid_input(value) or not self._valid_input(key):
+            raise ValueError("Invalid input value or key size exceeded the maximum limit.")
         if isinstance(value, dict):
             self._store_nested_dict(key, value)
         else:
@@ -1126,7 +1128,7 @@ class RedisDict:
         keys = list(self._scan_keys(key))
         if len(keys) == 0:
             return {}
-        to_rm = keys[0].rfind(':') + 1
+        to_rm = len(self.namespace) + 1
         return dict(
             zip([i[to_rm:] for i in keys], (self._transform(cast(str, i)) for i in cast(List[Any], self.redis.mget(keys)) if i is not None))
         )

--- a/src/redis_dict/python_dict.py
+++ b/src/redis_dict/python_dict.py
@@ -141,17 +141,11 @@ class PythonRedisDict(RedisDict):
 
         return self._transform(result)
 
-    def __len__(self) -> int:
-        """
-        Get the number of items in the RedisDict, analogous to a dictionary.
-
-        Returns:
-            int: The number of items in the RedisDict.
-        """
-        return self._insertion_order_len()
-
     def _scan_keys(self, search_term: str = '', full_scan: bool = False) -> Iterator[str]:
-        return self._insertion_order_iter()
+        prefix = self._create_iter_query(search_term).rstrip('*')
+        for key in self._insertion_order_iter():
+            if key.startswith(prefix):
+                yield key
 
     def clear(self) -> None:
         """Remove all key-value pairs from the RedisDict in one batch operation using pipelining.

--- a/src/redis_dict/python_dict.py
+++ b/src/redis_dict/python_dict.py
@@ -1,5 +1,5 @@
 """Python Redis Dict module."""
-from typing import Any, Iterator, Tuple, Union, Optional, List, Dict
+from typing import Any, Iterator, Tuple, Union, Optional, List, Dict, cast
 
 import time
 from datetime import timedelta
@@ -292,10 +292,13 @@ class PythonRedisDict(RedisDict):
             if first:
                 cursor = 0
                 first = False
-            cursor, data = self.get_redis.zscan(
-                name=self._insertion_order_key,
-                cursor=cursor,
-                count=1
+            cursor, data = cast(
+                Tuple[int, List[Tuple[str, float]]],
+                self.get_redis.zscan(
+                    name=self._insertion_order_key,
+                    cursor=cursor,
+                    count=1,
+                ),
             )
             yield from (item[0] for item in data)
 
@@ -327,5 +330,5 @@ class PythonRedisDict(RedisDict):
         Returns:
             Union[str, None]: The most recently inserted key, or None if the dictionary is empty.
         """
-        result = self.redis.zrange(self._insertion_order_key, -1, -1)
+        result = cast(List[str], self.redis.zrange(self._insertion_order_key, -1, -1))
         return result[0] if result else None

--- a/tests/misc/tests_asserts.py
+++ b/tests/misc/tests_asserts.py
@@ -76,9 +76,12 @@ items = {'k1': 'v1', 'k2': 'v2', 'k3': 'v3'}
 for key, val in items.items():
     dd.chain_set(['keys', key], val)
 
-assert len(dd) == len(items)
+assert len(dd) == 1
+assert dd['keys'] == items
+sep = dd.separator
 assert sorted(dd.multi_get('keys')) == sorted(list(items.values()))
-assert dd.multi_dict('keys') == items
+expected_multi = {f'keys{sep}{k}': v for k, v in items.items()}
+assert dd.multi_dict('keys') == expected_multi
 
 long_key = 'thekeyislongbutstill'
 items = {'K1': 'V1', 'KK22': 'VV22', 'KKK333': 'VVV333'}
@@ -86,7 +89,8 @@ for key, val in items.items():
     dd.chain_set([long_key, key], val)
 
 assert sorted(dd.multi_get(long_key)) == sorted(list(items.values()))
-assert dd.multi_dict(long_key) == items
+expected_multi = {f'{long_key}{sep}{k}': v for k, v in items.items()}
+assert dd.multi_dict(long_key) == expected_multi
 dd.multi_del(long_key)
 
 dd['one_item'] = 'im here'

--- a/tests/misc/tests_asserts.py
+++ b/tests/misc/tests_asserts.py
@@ -78,7 +78,7 @@ for key, val in items.items():
 
 assert len(dd) == 1
 assert dd['keys'] == items
-sep = dd.separator
+sep = dd.chain_separator
 assert sorted(dd.multi_get('keys')) == sorted(list(items.values()))
 expected_multi = {f'keys{sep}{k}': v for k, v in items.items()}
 assert dd.multi_dict('keys') == expected_multi

--- a/tests/unit/tests.py
+++ b/tests/unit/tests.py
@@ -2254,7 +2254,7 @@ class TestRedisDictMulti(unittest.TestCase):
         """Test setting a chain with 2 elements."""
         self.r.chain_set(['foo', 'bar'], 'melons')
 
-        sep = self.r.separator
+        sep = self.r.chain_separator
         expected_key = '{}:foo{}bar'.format(TEST_NAMESPACE_PREFIX, sep)
         self.assertEqual(self.redisdb.get(expected_key), b'str:melons')
 

--- a/tests/unit/tests.py
+++ b/tests/unit/tests.py
@@ -2254,7 +2254,8 @@ class TestRedisDictMulti(unittest.TestCase):
         """Test setting a chain with 2 elements."""
         self.r.chain_set(['foo', 'bar'], 'melons')
 
-        expected_key = '{}:foo:bar'.format(TEST_NAMESPACE_PREFIX)
+        sep = self.r.separator
+        expected_key = '{}:foo{}bar'.format(TEST_NAMESPACE_PREFIX, sep)
         self.assertEqual(self.redisdb.get(expected_key), b'str:melons')
 
     def test_chain_set_overwrite(self):

--- a/tests/unit/tests_configurable_separator.py
+++ b/tests/unit/tests_configurable_separator.py
@@ -1,0 +1,92 @@
+"""Tests for configurable chain separator (Issue #52).
+
+The chain separator defaults to '➡️    ' (right-arrow emoji + spaces) to avoid
+key collisions.  Users can supply any explicit separator instead.
+"""
+import unittest
+
+import redis
+
+from redis_dict import RedisDict
+from redis_dict.core import _DEFAULT_SEPARATOR
+
+
+TEST_NAMESPACE_PREFIX = '__test_separator_8129__'
+
+redis_config = {
+    'host': 'localhost',
+    'port': 6379,
+    'db': 11,
+}
+
+
+class TestConfigurableSeparator(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.redisdb = redis.StrictRedis(**redis_config)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.clear_test_namespace()
+
+    @classmethod
+    def create_redis_dict(cls, namespace=TEST_NAMESPACE_PREFIX, **kwargs):
+        config = redis_config.copy()
+        config.update(kwargs)
+        return RedisDict(namespace=namespace, **config)
+
+    @classmethod
+    def clear_test_namespace(cls):
+        for key in cls.redisdb.scan_iter('{}:*'.format(TEST_NAMESPACE_PREFIX)):
+            cls.redisdb.delete(key)
+
+    def setUp(self):
+        self.clear_test_namespace()
+
+    def tearDown(self):
+        self.clear_test_namespace()
+
+    def test_default_separator_is_arrow(self):
+        """Default chain separator is the collision-safe emoji+spaces string."""
+        r = self.create_redis_dict()
+        self.assertEqual(r.separator, _DEFAULT_SEPARATOR)
+
+    def test_chain_set_slash_separator_redis_key(self):
+        """chain_set with '/' separator creates the correct Redis key."""
+        r = self.create_redis_dict(separator='/')
+        r.chain_set(['foo', 'bar'], 'melons')
+        self.assertEqual(self.redisdb.get('{}:foo/bar'.format(TEST_NAMESPACE_PREFIX)), b'str:melons')
+
+    def test_chain_get_slash_separator(self):
+        """chain_get round-trips through a '/' separator."""
+        r = self.create_redis_dict(separator='/')
+        r.chain_set(['foo', 'bar'], 'melons')
+        self.assertEqual(r.chain_get(['foo', 'bar']), 'melons')
+
+    def test_chain_del_slash_separator(self):
+        """chain_del removes the key built with a custom separator."""
+        r = self.create_redis_dict(separator='/')
+        r.chain_set(['foo', 'bar'], 'melons')
+        r.chain_del(['foo', 'bar'])
+        with self.assertRaises(KeyError):
+            r.chain_get(['foo', 'bar'])
+
+    def test_multi_chain_get_slash_separator(self):
+        """multi_chain_get works correctly with a custom separator."""
+        r = self.create_redis_dict(separator='/')
+        r.chain_set(['foo', 'bar', 'bar'], 'barbar')
+        r.chain_set(['foo', 'bar', 'baz'], 'bazbaz')
+        self.assertEqual(sorted(r.multi_chain_get(['foo', 'bar'])), sorted(['barbar', 'bazbaz']))
+
+    def test_separator_avoids_colon_key_collision(self):
+        """With '/' separator, a user key containing ':' does not collide with chain key."""
+        r = self.create_redis_dict(separator='/')
+        r['foo:bar'] = 'direct'
+        r.chain_set(['foo', 'bar'], 'chained')
+        self.assertEqual(r['foo:bar'], 'direct')
+        self.assertEqual(r.chain_get(['foo', 'bar']), 'chained')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/tests_configurable_separator.py
+++ b/tests/unit/tests_configurable_separator.py
@@ -1,14 +1,14 @@
 """Tests for configurable chain separator (Issue #52).
 
-The chain separator defaults to '➡️    ' (right-arrow emoji + spaces) to avoid
-key collisions.  Users can supply any explicit separator instead.
+The chain separator defaults to ':'.  Users can supply any explicit
+separator instead.
 """
 import unittest
 
 import redis
 
 from redis_dict import RedisDict
-from redis_dict.core import _DEFAULT_SEPARATOR
+from redis_dict.core import _DEFAULT_CHAIN_SEPARATOR
 
 
 TEST_NAMESPACE_PREFIX = '__test_separator_8129__'
@@ -47,26 +47,26 @@ class TestConfigurableSeparator(unittest.TestCase):
     def tearDown(self):
         self.clear_test_namespace()
 
-    def test_default_separator_is_arrow(self):
-        """Default chain separator is the collision-safe emoji+spaces string."""
+    def test_default_separator_is_colon(self):
+        """Default chain separator is ':'."""
         r = self.create_redis_dict()
-        self.assertEqual(r.separator, _DEFAULT_SEPARATOR)
+        self.assertEqual(r.chain_separator, _DEFAULT_CHAIN_SEPARATOR)
 
     def test_chain_set_slash_separator_redis_key(self):
         """chain_set with '/' separator creates the correct Redis key."""
-        r = self.create_redis_dict(separator='/')
+        r = self.create_redis_dict(chain_separator='/')
         r.chain_set(['foo', 'bar'], 'melons')
         self.assertEqual(self.redisdb.get('{}:foo/bar'.format(TEST_NAMESPACE_PREFIX)), b'str:melons')
 
     def test_chain_get_slash_separator(self):
         """chain_get round-trips through a '/' separator."""
-        r = self.create_redis_dict(separator='/')
+        r = self.create_redis_dict(chain_separator='/')
         r.chain_set(['foo', 'bar'], 'melons')
         self.assertEqual(r.chain_get(['foo', 'bar']), 'melons')
 
     def test_chain_del_slash_separator(self):
         """chain_del removes the key built with a custom separator."""
-        r = self.create_redis_dict(separator='/')
+        r = self.create_redis_dict(chain_separator='/')
         r.chain_set(['foo', 'bar'], 'melons')
         r.chain_del(['foo', 'bar'])
         with self.assertRaises(KeyError):
@@ -74,14 +74,14 @@ class TestConfigurableSeparator(unittest.TestCase):
 
     def test_multi_chain_get_slash_separator(self):
         """multi_chain_get works correctly with a custom separator."""
-        r = self.create_redis_dict(separator='/')
+        r = self.create_redis_dict(chain_separator='/')
         r.chain_set(['foo', 'bar', 'bar'], 'barbar')
         r.chain_set(['foo', 'bar', 'baz'], 'bazbaz')
         self.assertEqual(sorted(r.multi_chain_get(['foo', 'bar'])), sorted(['barbar', 'bazbaz']))
 
     def test_separator_avoids_colon_key_collision(self):
         """With '/' separator, a user key containing ':' does not collide with chain key."""
-        r = self.create_redis_dict(separator='/')
+        r = self.create_redis_dict(chain_separator='/')
         r['foo:bar'] = 'direct'
         r.chain_set(['foo', 'bar'], 'chained')
         self.assertEqual(r['foo:bar'], 'direct')

--- a/tests/unit/tests_nested_dict.py
+++ b/tests/unit/tests_nested_dict.py
@@ -10,9 +10,9 @@ import unittest
 import redis
 
 from redis_dict import RedisDict
-from redis_dict.core import _DEFAULT_SEPARATOR
+from redis_dict.core import _DEFAULT_CHAIN_SEPARATOR
 
-SEP = _DEFAULT_SEPARATOR
+SEP = _DEFAULT_CHAIN_SEPARATOR
 
 TEST_NAMESPACE_PREFIX = '__test_nested_dict_8130__'
 
@@ -134,7 +134,7 @@ class TestNestedDict(_NestedDictTestBase):
 
     def test_nested_dict_with_custom_separator(self):
         """Nested dict works correctly combined with a non-default separator."""
-        r = self.create_redis_dict(separator='/')
+        r = self.create_redis_dict(chain_separator='/')
         r['var'] = {'c': 1, 'c2': 3}
         self.assertEqual(self.redisdb.get('{}:var/c'.format(TEST_NAMESPACE_PREFIX)), b'int:1')
         self.assertEqual(self.redisdb.get('{}:var/c2'.format(TEST_NAMESPACE_PREFIX)), b'int:3')

--- a/tests/unit/tests_nested_dict.py
+++ b/tests/unit/tests_nested_dict.py
@@ -240,6 +240,35 @@ class TestNestedDict(_NestedDictTestBase):
         self.assertEqual(value, {'c': 1, 'c2': 3})
         self.assertEqual(len(r), 0)
 
+    # --- empty dict ---
+
+    def test_empty_dict_roundtrip(self):
+        """Setting a key to {} stores and retrieves an empty dict without KeyError."""
+        r = self.create_redis_dict()
+        r['var'] = {}
+        self.assertEqual(r['var'], {})
+
+    def test_empty_dict_in_contains(self):
+        """A key set to {} is found by the 'in' operator."""
+        r = self.create_redis_dict()
+        r['var'] = {}
+        self.assertIn('var', r)
+
+    def test_dict_with_empty_dict_value_roundtrip(self):
+        """A dict whose only leaf values are empty dicts round-trips correctly."""
+        r = self.create_redis_dict()
+        r['var'] = {'a': {}}
+        self.assertEqual(r['var'], {'a': {}})
+
+    def test_overwrite_with_empty_dict(self):
+        """Overwriting a populated nested dict with {} stores an empty dict and removes old chain keys."""
+        r = self.create_redis_dict()
+        r['var'] = {'c': 1, 'c2': 3}
+        r['var'] = {}
+        self.assertEqual(r['var'], {})
+        self.assertIsNone(self.redisdb.get(f'{TEST_NAMESPACE_PREFIX}:var{SEP}c'))
+        self.assertIsNone(self.redisdb.get(f'{TEST_NAMESPACE_PREFIX}:var{SEP}c2'))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/tests_nested_dict.py
+++ b/tests/unit/tests_nested_dict.py
@@ -107,6 +107,24 @@ class TestNestedDict(_NestedDictTestBase):
         r['key'] = 'hello'
         self.assertEqual(r['key'], 'hello')
 
+    def test_subscript_assignment_updates_redis(self):
+        """rd['key']['sub'] = value persists the new leaf value in Redis."""
+        r = self.create_redis_dict()
+        r['var'] = {'c': 1, 'c2': 3}
+        r['var']['c'] = 2
+        self.assertEqual(r['var'], {'c': 2, 'c2': 3})
+        self.assertEqual(self.redisdb.get(f'{TEST_NAMESPACE_PREFIX}:var{SEP}c'), b'int:2')
+
+    def test_subscript_assignment_deep_nesting(self):
+        """rd['key']['a']['b'] = value persists correctly for deep nesting."""
+        r = self.create_redis_dict()
+        r['root'] = {'a': {'b': 1, 'c': 2}}
+        r['root']['a']['b'] = 99
+        self.assertEqual(r['root'], {'a': {'b': 99, 'c': 2}})
+        self.assertEqual(
+            self.redisdb.get(f'{TEST_NAMESPACE_PREFIX}:root{SEP}a{SEP}b'), b'int:99'
+        )
+
     def test_chain_set_and_nested_dict_interoperable(self):
         """chain_set can add sub-keys to a key that was set as a nested dict."""
         r = self.create_redis_dict()

--- a/tests/unit/tests_nested_dict.py
+++ b/tests/unit/tests_nested_dict.py
@@ -1,0 +1,227 @@
+"""Tests for nested dictionary support (Issue #52).
+
+Dict values are always stored as individual chain keys so that each leaf
+value is managed independently by Redis.  Reading the parent key reassembles
+the dict transparently, including arbitrary-depth nesting.  No opt-in flag
+is required.
+"""
+import unittest
+
+import redis
+
+from redis_dict import RedisDict
+from redis_dict.core import _DEFAULT_SEPARATOR
+
+SEP = _DEFAULT_SEPARATOR
+
+TEST_NAMESPACE_PREFIX = '__test_nested_dict_8130__'
+
+redis_config = {
+    'host': 'localhost',
+    'port': 6379,
+    'db': 11,
+}
+
+
+class _NestedDictTestBase(unittest.TestCase):
+    """Shared setup/teardown for nested dict test classes."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.redisdb = redis.StrictRedis(**redis_config)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.clear_test_namespace()
+
+    @classmethod
+    def create_redis_dict(cls, namespace=TEST_NAMESPACE_PREFIX, **kwargs):
+        config = redis_config.copy()
+        config.update(kwargs)
+        return RedisDict(namespace=namespace, **config)
+
+    @classmethod
+    def clear_test_namespace(cls):
+        for key in cls.redisdb.scan_iter('{}:*'.format(TEST_NAMESPACE_PREFIX)):
+            cls.redisdb.delete(key)
+
+    def setUp(self):
+        self.clear_test_namespace()
+
+    def tearDown(self):
+        self.clear_test_namespace()
+
+
+class TestNestedDict(_NestedDictTestBase):
+    """Tests for always-on nested dict support."""
+
+    def test_dict_stored_as_individual_chain_keys(self):
+        """Dict assignment creates one Redis key per leaf item; no sentinel at the parent key."""
+        r = self.create_redis_dict()
+        r['var'] = {'c': 1, 'c2': 3}
+        self.assertEqual(self.redisdb.get(f'{TEST_NAMESPACE_PREFIX}:var{SEP}c'), b'int:1')
+        self.assertEqual(self.redisdb.get(f'{TEST_NAMESPACE_PREFIX}:var{SEP}c2'), b'int:3')
+        # Parent key must not exist — no sentinel is stored.
+        self.assertIsNone(self.redisdb.get(f'{TEST_NAMESPACE_PREFIX}:var'))
+
+    def test_getitem_reassembles_nested_dict(self):
+        """__getitem__ transparently assembles chain keys back into a dict."""
+        r = self.create_redis_dict()
+        r['var'] = {'c': 1, 'c2': 3}
+        self.assertEqual(r['var'], {'c': 1, 'c2': 3})
+
+    def test_contains_nested_dict_key(self):
+        """'in' returns True when chain keys exist for the given parent key."""
+        r = self.create_redis_dict()
+        r['var'] = {'c': 1}
+        self.assertIn('var', r)
+
+    def test_del_removes_all_chain_keys(self):
+        """Deleting a nested dict key removes all associated chain keys from Redis."""
+        r = self.create_redis_dict()
+        r['var'] = {'c': 1, 'c2': 3}
+        del r['var']
+        with self.assertRaises(KeyError):
+            _ = r['var']
+        self.assertIsNone(self.redisdb.get(f'{TEST_NAMESPACE_PREFIX}:var{SEP}c'))
+        self.assertIsNone(self.redisdb.get(f'{TEST_NAMESPACE_PREFIX}:var{SEP}c2'))
+
+    def test_overwrite_nested_dict_removes_stale_keys(self):
+        """Overwriting a nested dict purges old chain keys not in the new dict."""
+        r = self.create_redis_dict()
+        r['var'] = {'c': 1, 'old_key': 99}
+        r['var'] = {'c': 2, 'new_key': 42}
+        self.assertEqual(r['var'], {'c': 2, 'new_key': 42})
+        self.assertIsNone(self.redisdb.get(f'{TEST_NAMESPACE_PREFIX}:var{SEP}old_key'))
+
+    def test_replace_nested_dict_with_scalar(self):
+        """Assigning a scalar after a nested dict replaces it correctly."""
+        r = self.create_redis_dict()
+        r['var'] = {'c': 1}
+        r['var'] = 'scalar'
+        self.assertEqual(r['var'], 'scalar')
+
+    def test_scalar_values_unaffected(self):
+        """Scalar values still work normally."""
+        r = self.create_redis_dict()
+        r['key'] = 'hello'
+        self.assertEqual(r['key'], 'hello')
+
+    def test_chain_set_and_nested_dict_interoperable(self):
+        """chain_set can add sub-keys to a key that was set as a nested dict."""
+        r = self.create_redis_dict()
+        r['var'] = {'c': 1}
+        r.chain_set(['var', 'd'], 2)
+        self.assertEqual(r['var'], {'c': 1, 'd': 2})
+
+    def test_nested_dict_with_custom_separator(self):
+        """Nested dict works correctly combined with a non-default separator."""
+        r = self.create_redis_dict(separator='/')
+        r['var'] = {'c': 1, 'c2': 3}
+        self.assertEqual(self.redisdb.get('{}:var/c'.format(TEST_NAMESPACE_PREFIX)), b'int:1')
+        self.assertEqual(self.redisdb.get('{}:var/c2'.format(TEST_NAMESPACE_PREFIX)), b'int:3')
+        self.assertEqual(r['var'], {'c': 1, 'c2': 3})
+
+    def test_deep_nested_dict_stored_as_leaf_chain_keys(self):
+        """A multi-level nested dict is flattened to individual leaf keys in Redis.
+
+        No parent key is stored (no sentinel); intermediate path segments are
+        not stored either.
+        """
+        r = self.create_redis_dict()
+        r['root'] = {'a': {'b': 1, 'c': 2}}
+        self.assertEqual(
+            self.redisdb.get(f'{TEST_NAMESPACE_PREFIX}:root{SEP}a{SEP}b'), b'int:1'
+        )
+        self.assertEqual(
+            self.redisdb.get(f'{TEST_NAMESPACE_PREFIX}:root{SEP}a{SEP}c'), b'int:2'
+        )
+        # Top-level parent key must not exist — no sentinel is stored.
+        self.assertIsNone(self.redisdb.get(f'{TEST_NAMESPACE_PREFIX}:root'))
+        # Intermediate path segment is not stored.
+        self.assertIsNone(self.redisdb.get(f'{TEST_NAMESPACE_PREFIX}:root{SEP}a'))
+
+    def test_deep_nested_dict_round_trips(self):
+        """A multi-level nested dict is reassembled correctly on read."""
+        r = self.create_redis_dict()
+        original = {'a': {'b': 1, 'c': 2}, 'd': 3}
+        r['root'] = original
+        self.assertEqual(r['root'], original)
+
+    def test_three_level_nesting_round_trips(self):
+        """Three levels of nesting are stored and reassembled correctly."""
+        r = self.create_redis_dict()
+        original = {'x': {'y': {'z': 42}}}
+        r['root'] = original
+        self.assertEqual(r['root'], original)
+
+    def test_deep_nested_dict_del_removes_all_leaf_keys(self):
+        """Deleting a deeply nested dict key removes all leaf chain keys."""
+        r = self.create_redis_dict()
+        r['root'] = {'a': {'b': 1, 'c': 2}}
+        del r['root']
+        with self.assertRaises(KeyError):
+            _ = r['root']
+        self.assertIsNone(self.redisdb.get(f'{TEST_NAMESPACE_PREFIX}:root{SEP}a{SEP}b'))
+        self.assertIsNone(self.redisdb.get(f'{TEST_NAMESPACE_PREFIX}:root{SEP}a{SEP}c'))
+
+    # --- iteration and cardinality ---
+
+    def test_keys_returns_only_logical_top_level_keys(self):
+        """keys() returns the parent key, not the individual chain sub-keys."""
+        r = self.create_redis_dict()
+        r['var'] = {'c': 1, 'c2': 3}
+        self.assertEqual(sorted(r.keys()), ['var'])
+
+    def test_keys_mixed_scalar_and_nested(self):
+        """keys() includes both scalar keys and nested-dict root keys."""
+        r = self.create_redis_dict()
+        r['scalar'] = 42
+        r['nested'] = {'a': 1, 'b': 2}
+        self.assertEqual(sorted(r.keys()), ['nested', 'scalar'])
+
+    def test_items_returns_logical_pairs(self):
+        """items() yields (parent_key, assembled_dict), not raw chain sub-keys."""
+        r = self.create_redis_dict()
+        r['var'] = {'c': 1, 'c2': 3}
+        self.assertEqual(dict(r.items()), {'var': {'c': 1, 'c2': 3}})
+
+    def test_values_returns_assembled_dicts(self):
+        """values() yields the assembled dict, not individual leaf values."""
+        r = self.create_redis_dict()
+        r['var'] = {'c': 1, 'c2': 3}
+        self.assertEqual(list(r.values()), [{'c': 1, 'c2': 3}])
+
+    def test_len_counts_logical_keys(self):
+        """len() counts nested dicts as a single item, not as one per leaf."""
+        r = self.create_redis_dict()
+        r['scalar'] = 99
+        r['nested'] = {'x': 1, 'y': 2}
+        self.assertEqual(len(r), 2)
+
+    def test_to_dict_assembles_nested_dicts(self):
+        """to_dict() reconstructs nested dicts instead of exposing chain sub-keys."""
+        r = self.create_redis_dict()
+        r['a'] = 1
+        r['b'] = {'x': 10, 'y': 20}
+        self.assertEqual(r.to_dict(), {'a': 1, 'b': {'x': 10, 'y': 20}})
+
+    def test_iter_yields_logical_keys(self):
+        """Iterating the RedisDict yields logical top-level keys only."""
+        r = self.create_redis_dict()
+        r['var'] = {'c': 1}
+        r['plain'] = 'hello'
+        self.assertEqual(sorted(r), ['plain', 'var'])
+
+    def test_popitem_returns_logical_pair(self):
+        """popitem() returns (parent_key, assembled_dict), not a chain sub-key."""
+        r = self.create_redis_dict()
+        r['var'] = {'c': 1, 'c2': 3}
+        key, value = r.popitem()
+        self.assertEqual(key, 'var')
+        self.assertEqual(value, {'c': 1, 'c2': 3})
+        self.assertEqual(len(r), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implements the recommendations from issue #52.

**Test Code:**
```python
from redis_dict import RedisDict

a = RedisDict()
a.clear()
a["var"]={"c":1, "c2":3}
print("Original: ", a)

a["var"]["c"] = 2
print("After updating through assignment, direct value: ", a, ",  list of true redis keys: ", list(a._scan_keys("*")))

a.chain_set(("var","c"),10)
print("After updating through chain_set, direct value: ", a, ",  list of true redis keys: ", list(a._scan_keys("*")))
```

**Behaviour Before this PR:**

```
Original:  {'var': {'c': 1, 'c2': 3}}
After updating through assignment, direct value:  {'var': {'c': 1, 'c2': 3}} ,  list of true redis keys:  ['main:var']
After updating through chain_set, direct value:  {'var:c': 10, 'var': {'c': 1, 'c2': 3}} ,  list of true redis keys:  ['main:var:c', 'main:var']

```

**Behaviour With this PR:**
```
Original:  {'var': {'c': 1, 'c2': 3}}
After updating through assignment, direct value:  {'var': {'c': 2, 'c2': 3}} ,  list of true redis keys:  ['main:var➡️    c', 'main:var➡️    c2']
After updating through chain_set, direct value:  {'var': {''c': 10, c2': 3}} ,  list of true redis keys:  ['main:var➡️    c', 'main:var➡️    c2']
```